### PR TITLE
fix: #1 time count bug

### DIFF
--- a/lib/screens/mensetsu_page.dart
+++ b/lib/screens/mensetsu_page.dart
@@ -32,6 +32,10 @@ class _MensetsuPageState extends State<MensetsuPage> {
   Timer? _timer;
 
   Future<void> _speak(String text) async {
+    if (_timer != null && _timer!.isActive) {
+      _timer!.cancel();
+    }
+
     await tts.setLanguage("ja");
     if (Platform.isAndroid) {
       await tts.setVoice({"name": "ja-jp-x-jab-network", "locale": "ja-JP"});


### PR DESCRIPTION
If it's a new device installing the app, there was a bug where the Timer couldn't accurately measure time when await started. Now, at the moment of initiation, it checks if the timer is active to prevent duplicate execution of time count